### PR TITLE
fix repoting nan violation after line feed

### DIFF
--- a/src/no-doubled-conjunctive-particle-ga.js
+++ b/src/no-doubled-conjunctive-particle-ga.js
@@ -55,7 +55,7 @@ export default function (context, options = {}) {
                     }
                     const current = conjunctiveParticleGaTokens[0];
                     const sentenceIndex = source.originalIndexFromPosition(sentence.loc.start);
-                    const currentIndex = sentenceIndex + (current.word_position - 1);
+                    const currentIndex = (sentenceIndex || 0) + (current.word_position - 1);
                     report(node, new RuleError(`文中に逆接の接続助詞 "が" が二回以上使われています。`, {
                         index: currentIndex
                     }));

--- a/test/no-doubled-conjunctive-particle-ga-test.js
+++ b/test/no-doubled-conjunctive-particle-ga-test.js
@@ -69,5 +69,15 @@ tester.run("no-doubled-conjunctive-particle-ga", rule, {
                 }
             ]
         },
+        {
+            text: "\n今日は早朝から出発したが、定刻には間に合わなかったが、無事会場に到着した。",
+            errors: [
+                {
+                    message: `文中に逆接の接続助詞 "が" が二回以上使われています。`,
+                    line: 2,
+                    column: 12
+                }
+            ]
+        },
     ]
 });


### PR DESCRIPTION
改行のみの行の直後の行で違反があるとcolumnがNaNでレポートされるのを修正します。
textlintのAPIをよくわかっていないので、直し方がこれでいいのか不安ではありますが。

多分 #15 も直るはずです。